### PR TITLE
Version bump

### DIFF
--- a/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
+++ b/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
     <Authors>mgibas,phnx47,TrapperHell</Authors>
     <Description>Serilog sink for Slack</Description>
-    <Version>2.0.3</Version>
+    <Version>2.0.4</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <PackageProjectUrl>https://github.com/serilog-contrib/serilog-sinks-slack</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
- Bump version of project to force a NuGet build with a bumped version, which will reflect the new project URL, and hopefully assign the icon