### PR TITLE
IBatchedLogEventSink implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Log.Logger = new LoggerConfiguration()
 Custom channel, username or icon:
 ```csharp
 Log.Logger = new LoggerConfiguration()
-    .WriteTo.Slack("https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", 20, 1000, TimeSpan.FromSeconds(10), "#general" ,"Im a Ghost", ":ghost:")
+    .WriteTo.Slack("https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", 20, TimeSpan.FromSeconds(10), "#general" ,"Im a Ghost", ":ghost:", queueLimit: 1000)
     .CreateLogger();
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Log.Logger = new LoggerConfiguration()
 Custom channel, username or icon:
 ```csharp
 Log.Logger = new LoggerConfiguration()
-    .WriteTo.Slack("https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",  20, TimeSpan.FromSeconds(10), "#general" ,"Im a Ghost", ":ghost:")
+    .WriteTo.Slack("https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", 20, 1000, TimeSpan.FromSeconds(10), "#general" ,"Im a Ghost", ":ghost:")
     .CreateLogger();
 ```
 
@@ -53,6 +53,7 @@ Advanced:
             WebHookUrl = "https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
             CustomChannel = "#test",
             BatchSizeLimit = 20,
+            QueueLimit = 1000,
             CustomIcon = ":ghost:",
             Period = TimeSpan.FromSeconds(10),
             ShowDefaultAttachments = false,

--- a/Serilog.Sinks.Slack.Sample/Program.cs
+++ b/Serilog.Sinks.Slack.Sample/Program.cs
@@ -11,7 +11,7 @@ namespace Serilog.Sinks.Slack.Sample
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
                 .WriteTo.Console(LogEventLevel.Debug)
-                //.WriteTo.Slack("https://hooks.slack.com/services/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", 20, 1000, TimeSpan.FromSeconds(10), "#test", "Im a Ghost", ":ghost:")
+                //.WriteTo.Slack("https://hooks.slack.com/services/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", 20, TimeSpan.FromSeconds(10), "#test", "Im a Ghost", ":ghost:", queueLimit: 1000)
                 .WriteTo.Slack(new SlackSinkOptions
                 {
                     WebHookUrl = "https://hooks.slack.com/services/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",

--- a/Serilog.Sinks.Slack.Sample/Program.cs
+++ b/Serilog.Sinks.Slack.Sample/Program.cs
@@ -11,12 +11,13 @@ namespace Serilog.Sinks.Slack.Sample
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
                 .WriteTo.Console(LogEventLevel.Debug)
-                //.WriteTo.Slack("https://hooks.slack.com/services/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", 20, TimeSpan.FromSeconds(10), "#test", "Im a Ghost", ":ghost:")
+                //.WriteTo.Slack("https://hooks.slack.com/services/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", 20, 1000, TimeSpan.FromSeconds(10), "#test", "Im a Ghost", ":ghost:")
                 .WriteTo.Slack(new SlackSinkOptions
                 {
                     WebHookUrl = "https://hooks.slack.com/services/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",
                     CustomChannel = "#test",
                     BatchSizeLimit = 20,
+                    QueueLimit = 1000,
                     CustomIcon = ":ghost:",
                     Period = TimeSpan.FromSeconds(10),
                     ShowDefaultAttachments = false,

--- a/Serilog.Sinks.Slack/Models/SlackSinkOptions.cs
+++ b/Serilog.Sinks.Slack/Models/SlackSinkOptions.cs
@@ -58,6 +58,12 @@ namespace Serilog.Sinks.Slack.Models
         public int BatchSizeLimit { get; set; } = 50;
 
         /// <summary>
+        /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
+        /// for an unbounded queue. The default is <c>100000</c>.
+        /// </summary>
+        public int? QueueLimit { get; set; } = 100000;
+
+        /// <summary>
         /// Optional: The maximum period between message batches. Defaults to 5 seconds.
         /// </summary>
         public TimeSpan Period { get; set; } = TimeSpan.FromSeconds(5);

--- a/Serilog.Sinks.Slack/Models/SlackSinkOptions.cs
+++ b/Serilog.Sinks.Slack/Models/SlackSinkOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Serilog.Events;
+using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog.Sinks.Slack.Models
 {
@@ -104,5 +105,19 @@ namespace Serilog.Sinks.Slack.Models
         /// for an unbounded queue. The default is <c>100000</c>.
         /// </summary>
         public int? QueueLimit { get; set; } = 100000;
+
+        /// <summary>
+        /// Maps options to <see cref="PeriodicBatchingSinkOptions"/> for use with <see cref="PeriodicBatchingSink"/> ctor.
+        /// </summary>
+        /// <returns>Instance of <see cref="PeriodicBatchingSinkOptions"/> object.</returns>
+        internal PeriodicBatchingSinkOptions ToPeriodicBatchingSinkOptions()
+        {
+            return new PeriodicBatchingSinkOptions
+            {
+                BatchSizeLimit = BatchSizeLimit,
+                Period = Period,
+                QueueLimit = QueueLimit
+            };
+        }
     }
 }

--- a/Serilog.Sinks.Slack/Models/SlackSinkOptions.cs
+++ b/Serilog.Sinks.Slack/Models/SlackSinkOptions.cs
@@ -58,12 +58,6 @@ namespace Serilog.Sinks.Slack.Models
         public int BatchSizeLimit { get; set; } = 50;
 
         /// <summary>
-        /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
-        /// for an unbounded queue. The default is <c>100000</c>.
-        /// </summary>
-        public int? QueueLimit { get; set; } = 100000;
-
-        /// <summary>
         /// Optional: The maximum period between message batches. Defaults to 5 seconds.
         /// </summary>
         public TimeSpan Period { get; set; } = TimeSpan.FromSeconds(5);
@@ -104,5 +98,11 @@ namespace Serilog.Sinks.Slack.Models
         /// Default is derived from the current culture. 
         /// </summary>
         public string TimestampFormat { get; set; }
+
+        /// <summary>
+        /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
+        /// for an unbounded queue. The default is <c>100000</c>.
+        /// </summary>
+        public int? QueueLimit { get; set; } = 100000;
     }
 }

--- a/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
+++ b/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
+++ b/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
     <Authors>mgibas,phnx47,TrapperHell</Authors>
     <Description>Serilog sink for Slack</Description>
-    <Version>2.0.4</Version>
+    <Version>2.1.0</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <PackageProjectUrl>https://github.com/serilog-contrib/serilog-sinks-slack</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Serilog.Sinks.Slack/SlackLoggerConfigurationExtensions.cs
+++ b/Serilog.Sinks.Slack/SlackLoggerConfigurationExtensions.cs
@@ -26,8 +26,9 @@ namespace Serilog.Sinks.Slack
         /// </summary>
         /// <param name="loggerSinkConfiguration">Instance of <see cref="LoggerSinkConfiguration"/> object.</param>
         /// <param name="webhookUrl">Slack team post URI.</param>
-        /// <param name="batchSizeLimit">The time to wait between checking for event batches.</param>
-        /// <param name="period">The time to wait between checking for event batches..</param>
+        /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
+        /// <param name="queueLimit">The maximum number of events to hold in the sink's internal queue, or <c>null</c> for an unbounded queue. The default is <c>100000</c>.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="customChannel">Name of Slack channel to which message should be posted.</param>
         /// <param name="customUsername">User name that will be displayed as a name of the message sender.</param>
         /// <param name="customIcon">Icon that will be used as a sender avatar.</param>
@@ -47,6 +48,7 @@ namespace Serilog.Sinks.Slack
             this LoggerSinkConfiguration loggerSinkConfiguration,
             string webhookUrl,
             int? batchSizeLimit = null,
+            int? queueLimit = 100000,
             TimeSpan? period = null,
             string customChannel = null,
             string customUsername = null,
@@ -69,6 +71,7 @@ namespace Serilog.Sinks.Slack
                 webhookUrl,
                 formatter,
                 batchSizeLimit,
+                queueLimit,
                 period,
                 customChannel,
                 customUsername,
@@ -99,8 +102,9 @@ namespace Serilog.Sinks.Slack
         /// events into text for Slack. If control of regular text formatting is required, use the other overload of 
         /// <see cref="SlackSink"/> and specify the outputTemplate parameter instead.
         /// </param>
-        /// <param name="batchSizeLimit">The time to wait between checking for event batches.</param>
-        /// <param name="period">The time to wait between checking for event batches..</param>
+        /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
+        /// <param name="queueLimit">The maximum number of events to hold in the sink's internal queue, or <c>null</c> for an unbounded queue. The default is <c>100000</c>.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="customChannel">Name of Slack channel to which message should be posted.</param>
         /// <param name="customUsername">User name that will be displayed as a name of the message sender.</param>
         /// <param name="customIcon">Icon that will be used as a sender avatar.</param>
@@ -119,6 +123,7 @@ namespace Serilog.Sinks.Slack
             string webhookUrl,
             ITextFormatter formatter,
             int? batchSizeLimit = null,
+            int? queueLimit = 100000,
             TimeSpan? period = null,
             string customChannel = null,
             string customUsername = null,
@@ -146,7 +151,8 @@ namespace Serilog.Sinks.Slack
                 PropertyAllowList = propertyAllowList,
                 PropertyDenyList = propertyDenyList,
                 ShowExceptionAttachments = showExceptionAttachments,
-                TimestampFormat = timestampFormat
+                TimestampFormat = timestampFormat,
+                QueueLimit = queueLimit
             };
 
             if (batchSizeLimit.HasValue)

--- a/Serilog.Sinks.Slack/SlackLoggerConfigurationExtensions.cs
+++ b/Serilog.Sinks.Slack/SlackLoggerConfigurationExtensions.cs
@@ -27,7 +27,6 @@ namespace Serilog.Sinks.Slack
         /// <param name="loggerSinkConfiguration">Instance of <see cref="LoggerSinkConfiguration"/> object.</param>
         /// <param name="webhookUrl">Slack team post URI.</param>
         /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
-        /// <param name="queueLimit">The maximum number of events to hold in the sink's internal queue, or <c>null</c> for an unbounded queue. The default is <c>100000</c>.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="customChannel">Name of Slack channel to which message should be posted.</param>
         /// <param name="customUsername">User name that will be displayed as a name of the message sender.</param>
@@ -43,12 +42,12 @@ namespace Serilog.Sinks.Slack
         /// <param name="propertyAllowList">If specified, only properties that match (case-insensitive) the name in the list are logged. Takes precedence over <see cref="SlackSinkOptions.PropertyDenyList"/></param>
         /// <param name="propertyDenyList">If specified, only properties that are not in this list are logged.</param>
         /// <param name="timestampFormat">The <see href="https://docs.microsoft.com/dotnet/standard/base-types/standard-date-and-time-format-strings"> date and time format</see> for timestamps in messages.</param>
+        /// <param name="queueLimit">The maximum number of events to hold in the sink's internal queue, or <c>null</c> for an unbounded queue. The default is <c>100000</c>.</param>
         /// <returns>Instance of <see cref="LoggerConfiguration"/> object.</returns>
         public static LoggerConfiguration Slack(
             this LoggerSinkConfiguration loggerSinkConfiguration,
             string webhookUrl,
             int? batchSizeLimit = null,
-            int? queueLimit = 100000,
             TimeSpan? period = null,
             string customChannel = null,
             string customUsername = null,
@@ -63,7 +62,8 @@ namespace Serilog.Sinks.Slack
             IFormatProvider formatProvider = null,
             List<string> propertyAllowList = null,
             List<string> propertyDenyList = null,
-            string timestampFormat = null)
+            string timestampFormat = null,
+            int? queueLimit = 100000)
         {
 
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
@@ -71,7 +71,6 @@ namespace Serilog.Sinks.Slack
                 webhookUrl,
                 formatter,
                 batchSizeLimit,
-                queueLimit,
                 period,
                 customChannel,
                 customUsername,
@@ -84,7 +83,8 @@ namespace Serilog.Sinks.Slack
                 restrictedToMinimumLevel,
                 propertyAllowList,
                 propertyDenyList,
-                timestampFormat);
+                timestampFormat,
+                queueLimit);
         }
 
         /// <summary>
@@ -103,7 +103,6 @@ namespace Serilog.Sinks.Slack
         /// <see cref="SlackSink"/> and specify the outputTemplate parameter instead.
         /// </param>
         /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
-        /// <param name="queueLimit">The maximum number of events to hold in the sink's internal queue, or <c>null</c> for an unbounded queue. The default is <c>100000</c>.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="customChannel">Name of Slack channel to which message should be posted.</param>
         /// <param name="customUsername">User name that will be displayed as a name of the message sender.</param>
@@ -117,13 +116,13 @@ namespace Serilog.Sinks.Slack
         /// <param name="propertyAllowList">If specified, only properties that match (case-insensitive) the name in the list are logged. Takes precedence over <see cref="SlackSinkOptions.PropertyDenyList"/></param>
         /// <param name="propertyDenyList">If specified, only properties that are not in this list are logged.</param>
         /// <param name="timestampFormat">The <see href="https://docs.microsoft.com/dotnet/standard/base-types/standard-date-and-time-format-strings"> date and time format</see> for timestamps in messages.</param>
+        /// <param name="queueLimit">The maximum number of events to hold in the sink's internal queue, or <c>null</c> for an unbounded queue. The default is <c>100000</c>.</param>
         /// <returns>Instance of <see cref="LoggerConfiguration"/> object.</returns>
         public static LoggerConfiguration Slack(
             this LoggerSinkConfiguration loggerSinkConfiguration,
             string webhookUrl,
             ITextFormatter formatter,
             int? batchSizeLimit = null,
-            int? queueLimit = 100000,
             TimeSpan? period = null,
             string customChannel = null,
             string customUsername = null,
@@ -136,7 +135,8 @@ namespace Serilog.Sinks.Slack
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             List<string> propertyAllowList = null,
             List<string> propertyDenyList = null,
-            string timestampFormat = null)
+            string timestampFormat = null,
+            int? queueLimit = 100000)
         {
             var slackSinkOptions = new SlackSinkOptions
             {

--- a/Serilog.Sinks.Slack/SlackSink.cs
+++ b/Serilog.Sinks.Slack/SlackSink.cs
@@ -34,7 +34,7 @@ namespace Serilog.Sinks.Slack
         /// <param name="options">Slack sink options object.</param>
         /// <param name="textFormatter">Formatter used to convert log events to text.</param>
         public SlackSink(SlackSinkOptions options, ITextFormatter textFormatter)
-            : base(options.BatchSizeLimit, options.Period)
+            : base(options.BatchSizeLimit, options.Period, options.QueueLimit ?? PeriodicBatchingSink.NoQueueLimit)
         {
             _options = options;
             _textFormatter = textFormatter;

--- a/Serilog.Sinks.Slack/SlackSink.cs
+++ b/Serilog.Sinks.Slack/SlackSink.cs
@@ -19,9 +19,9 @@ namespace Serilog.Sinks.Slack
     /// </summary>
     public class SlackSink : ILogEventSink, IBatchedLogEventSink, IDisposable
     {
-        private readonly HttpClient Client = new HttpClient();
+        private readonly HttpClient _client = new HttpClient();
 
-        private readonly JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings
+        private readonly JsonSerializerSettings _jsonSerializerSettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore
         };
@@ -63,8 +63,8 @@ namespace Serilog.Sinks.Slack
             {
                 if (logEvent.Level < _options.MinimumLogEventLevel) continue;
                 var message = CreateMessage(logEvent);
-                var json = JsonConvert.SerializeObject(message, jsonSerializerSettings);
-                await Client.PostAsync(_options.WebHookUrl, new StringContent(json));
+                var json = JsonConvert.SerializeObject(message, _jsonSerializerSettings);
+                await _client.PostAsync(_options.WebHookUrl, new StringContent(json));
             }
         }
 
@@ -92,7 +92,7 @@ namespace Serilog.Sinks.Slack
 
             if (disposing)
             {
-                Client.Dispose();
+                _client.Dispose();
                 _periodicBatchingSink.Dispose();
             }
 


### PR DESCRIPTION
As [suggested by the authors](https://github.com/serilog/serilog-sinks-periodicbatching/blob/db4250fa7706ebec56fb89055e6b6bf85c7df762/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSink.cs#L42) of `PeriodicBatchingSink`:
```
Implement `IBatchedLogEventSink` and use the `PeriodicBatchingSinkOptions` constructor.
```

This PR also adds support for the `QueueLimit` parameter. Its default value is `100000`, i.e. the same value used by `PeriodicBatchingSinkOptions`. It cannot be null since this value is already used to indicate a limitless queue. Having it as a default would probably lead to high memory usages without the user knowing.
