### PR TITLE
Adjust .NET Framework TLS support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,11 +6,12 @@ on:
 
 jobs:
   publish:
+    name: build, pack and publish
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2      
-    - name: Publish NuGet
-      uses: brandedoutcast/publish-nuget@v2.5.5
+    - uses: actions/checkout@v2
+    - name: Publish to NuGet
+      uses: rohith/publish-nuget@v2
       with:
         PROJECT_FILE_PATH: Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
         NUGET_KEY: ${{secrets.NUGET_KEY}}

--- a/Serilog.Sinks.Slack.sln
+++ b/Serilog.Sinks.Slack.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{721763D1-0FA7-42C4-A71B-91BBE31BB57D}"
 	ProjectSection(SolutionItems) = preProject
-		appveyor.yml = appveyor.yml
+		.github\workflows\publish.yml = .github\workflows\publish.yml
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
+++ b/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
     <Authors>mgibas,phnx47,TrapperHell</Authors>
     <Description>Serilog sink for Slack</Description>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <PackageProjectUrl>https://github.com/serilog-contrib/serilog-sinks-slack</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Serilog.Sinks.Slack/SlackSink.cs
+++ b/Serilog.Sinks.Slack/SlackSink.cs
@@ -31,6 +31,13 @@ namespace Serilog.Sinks.Slack
         private readonly PeriodicBatchingSink _periodicBatchingSink;
         private bool _disposed = false;
 
+#if NETFRAMEWORK
+        static SlackSink()
+        {
+            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
+        }
+#endif
+
         /// <summary>
         /// Initializes new instance of <see cref="SlackSink"/>.
         /// </summary>


### PR DESCRIPTION
- Explicitly allow TLS 1.2 support for the slack webhooks in case of .NET Framework, which should resolve issue #40
- Tentative adjustment of publish.yml file (and its inclusion in the solution)
- Bump version to 2.2.1