### PR TITLE
Using property CustomSlackChannel from logEvent as channel name override

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,11 @@ Log.Logger = new LoggerConfiguration()
     })
     .CreateLogger();
 ```
+
+Scope overriden channel name:
+```csharp
+using (_logger.BeginScope("{CustomSlackChannel}", customSlackChannel))
+{
+    _logger.LogCritical(exceptionToLog, message, args);
+}
+```

--- a/README.md
+++ b/README.md
@@ -64,10 +64,22 @@ Log.Logger = new LoggerConfiguration()
     .CreateLogger();
 ```
 
-Scope overridden channel name:
+It's possible to override `CustomChannel`, `CustomUserName`, `CustomIcon` configs using `LogEvent` properties.
+Config overrides can be enabled by specifying them in `SlackSinkOptions` property `PropertyOverrideList`.
 ```csharp
-using (_logger.BeginScope("{CustomSlackChannel}", customSlackChannel))
+new SlackSinkOptions
 {
-    _logger.LogCritical(exceptionToLog, message, args);
+    WebHookUrl = "https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    CustomChannel = "#static_channel_name",
+    CustomUserName = "User Foo",
+    MinimumLogEventLevel = LogEventLevel.Fatal,
+    PropertyOverrideList = new List<OverridableProperties>() { OverridableProperties.CustomChannel }
+});
+```
+Config override using `Scope`:
+```csharp
+using (_logger.BeginScope("{CustomChannel}", dynamicChannelName))
+{
+    _logger.LogCritical(exception, message, args);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Log.Logger = new LoggerConfiguration()
     .CreateLogger();
 ```
 
-Scope overriden channel name:
+Scope overridden channel name:
 ```csharp
 using (_logger.BeginScope("{CustomSlackChannel}", customSlackChannel))
 {

--- a/Serilog.Sinks.Slack/Enums/OverridableProperties.cs
+++ b/Serilog.Sinks.Slack/Enums/OverridableProperties.cs
@@ -1,0 +1,15 @@
+﻿using Serilog.Sinks.Slack.Models;
+
+namespace Serilog.Sinks.Slack.Enums
+{
+    /// <summary>
+    /// These properties can be used to override options at a message level.
+    /// Overrides can be enabled by adding their enum values to <see cref="SlackSinkOptions"> PropertyOverrideList property.
+    /// </summary>
+    public enum OverridableProperties
+    {
+        CustomChannel,
+        CustomUserName,
+        CustomIcon
+    }
+}

--- a/Serilog.Sinks.Slack/Models/SlackSinkOptions.cs
+++ b/Serilog.Sinks.Slack/Models/SlackSinkOptions.cs
@@ -96,9 +96,9 @@ namespace Serilog.Sinks.Slack.Models
         public List<string> PropertyDenyList { get; set; }
 
         /// <summary>
-        /// Optional: A list of <see cref="SlackSinkOptions"> properties that are being overridden by properties in the messages.
+        /// Optional: A hashset of <see cref="SlackSinkOptions"> properties that are being overridden by properties in the messages.
         /// </summary>
-        public List<OverridableProperties> PropertyOverrideList { get; set; }
+        public HashSet<OverridableProperties> PropertyOverrideList { get; set; }
 
         /// <summary>
         /// Optional: The <see href="https://docs.microsoft.com/dotnet/standard/base-types/standard-date-and-time-format-strings"> date and time format</see> used for timestamps in the messages.

--- a/Serilog.Sinks.Slack/Models/SlackSinkOptions.cs
+++ b/Serilog.Sinks.Slack/Models/SlackSinkOptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Serilog.Events;
 using Serilog.Sinks.PeriodicBatching;
+using Serilog.Sinks.Slack.Enums;
 
 namespace Serilog.Sinks.Slack.Models
 {
@@ -93,6 +94,11 @@ namespace Serilog.Sinks.Slack.Models
         /// Optional: A list of properties (including exception properties) that are excluded in the messages.
         /// </summary>
         public List<string> PropertyDenyList { get; set; }
+
+        /// <summary>
+        /// Optional: A list of <see cref="SlackSinkOptions"> properties that are being overridden by properties in the messages.
+        /// </summary>
+        public List<OverridableProperties> PropertyOverrideList { get; set; }
 
         /// <summary>
         /// Optional: The <see href="https://docs.microsoft.com/dotnet/standard/base-types/standard-date-and-time-format-strings"> date and time format</see> used for timestamps in the messages.

--- a/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
+++ b/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
     <Authors>mgibas,phnx47,TrapperHell</Authors>
     <Description>Serilog sink for Slack</Description>
-    <Version>2.2.1</Version>
+    <Version>2.2.2</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <PackageProjectUrl>https://github.com/serilog-contrib/serilog-sinks-slack</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Serilog.Sinks.Slack/SlackSink.cs
+++ b/Serilog.Sinks.Slack/SlackSink.cs
@@ -116,9 +116,9 @@ namespace Serilog.Sinks.Slack
                 return new Message
                 {
                     Text = textWriter.ToString(),
-                    Channel = GetPropertyFromException(logEvent, OverridableProperties.CustomChannel, _options.CustomChannel),
-                    UserName = GetPropertyFromException(logEvent, OverridableProperties.CustomUserName, _options.CustomUserName),
-                    IconEmoji = GetPropertyFromException(logEvent, OverridableProperties.CustomIcon, _options.CustomIcon),
+                    Channel = GetPropertyFromLogEvent(logEvent, OverridableProperties.CustomChannel, _options.CustomChannel),
+                    UserName = GetPropertyFromLogEvent(logEvent, OverridableProperties.CustomUserName, _options.CustomUserName),
+                    IconEmoji = GetPropertyFromLogEvent(logEvent, OverridableProperties.CustomIcon, _options.CustomIcon),
                     Attachments = CreateAttachments(logEvent).ToList()
                 };
             }
@@ -218,7 +218,7 @@ namespace Serilog.Sinks.Slack
             attachment.Fields.Add(field);
         }
 
-        private string GetPropertyFromException(LogEvent logEvent, OverridableProperties overridableProperty, string defaultValue)
+        private string GetPropertyFromLogEvent(LogEvent logEvent, OverridableProperties overridableProperty, string defaultValue)
         {
             if (!_options.PropertyOverrideList?.Contains(overridableProperty) ?? true) return defaultValue;
 

--- a/Serilog.Sinks.Slack/SlackSink.cs
+++ b/Serilog.Sinks.Slack/SlackSink.cs
@@ -112,10 +112,13 @@ namespace Serilog.Sinks.Slack
             {
                 _textFormatter.Format(logEvent, textWriter);
 
+                logEvent.Properties.TryGetValue("CustomSlackChannel", out var customChannelNameValue);
+                var channelName = customChannelNameValue is LogEventPropertyValue name ? name.ToString().Replace("\"", string.Empty) : _options.CustomChannel;
+
                 return new Message
                 {
                     Text = textWriter.ToString(),
-                    Channel = logEvent.Properties.ContainsKey("CustomSlackChannel") ? logEvent.Properties["CustomSlackChannel"].ToString().Replace("\"", string.Empty) : _options.CustomChannel,
+                    Channel = channelName,
                     UserName = _options.CustomUserName,
                     IconEmoji = _options.CustomIcon,
                     Attachments = CreateAttachments(logEvent).ToList()

--- a/Serilog.Sinks.Slack/SlackSink.cs
+++ b/Serilog.Sinks.Slack/SlackSink.cs
@@ -223,10 +223,10 @@ namespace Serilog.Sinks.Slack
             if (!_options.PropertyOverrideList?.Contains(overridableProperty) ?? true) return defaultValue;
 
             var overridablePropertyName = Enum.GetName(typeof(OverridableProperties), overridableProperty);
-            if (!logEvent.Properties.TryGetValue(overridablePropertyName, out var logEventPropertyValue))
+            if (!logEvent.Properties.TryGetValue(overridablePropertyName, out var value))
                 return defaultValue;
 
-            var stringValue = logEventPropertyValue.ToString().Replace("\"", string.Empty);
+            var stringValue = value is LogEventPropertyValue logEventPropertyValue ? logEventPropertyValue.ToString().Replace("\"", string.Empty) : defaultValue;
             return !string.IsNullOrEmpty(stringValue)
                 ? stringValue
                 : defaultValue;

--- a/Serilog.Sinks.Slack/SlackSink.cs
+++ b/Serilog.Sinks.Slack/SlackSink.cs
@@ -115,7 +115,7 @@ namespace Serilog.Sinks.Slack
                 return new Message
                 {
                     Text = textWriter.ToString(),
-                    Channel = _options.CustomChannel,
+                    Channel = logEvent.Properties.ContainsKey("CustomSlackChannel") ? logEvent.Properties["CustomSlackChannel"].ToString().Replace("\"", string.Empty) : _options.CustomChannel,
                     UserName = _options.CustomUserName,
                     IconEmoji = _options.CustomIcon,
                     Attachments = CreateAttachments(logEvent).ToList()


### PR DESCRIPTION
If such property exists in `logEvent` properties, then use it as slack channel name instead.
This way each logEvent message can have it's own channel specified.